### PR TITLE
Fix-Feature/US-92 Endpoint para listar Comentarios por IdNovedad.

### DIFF
--- a/OngProject/Core/Business/CommentBusiness.cs
+++ b/OngProject/Core/Business/CommentBusiness.cs
@@ -32,15 +32,20 @@ namespace OngProject.Core.Business
 
         public List<CommentDto> showListCommentDto(int id)
         {
-            var lista = _unitOfWork.CommentModelRepository.GetAll();
             List<CommentDto> listaFiltrada = new List<CommentDto>();
-            foreach (var item in lista)
+            var lista = _unitOfWork.CommentModelRepository.GetAll();
+            if (lista != null)
             {
-                if (item.News_Id == id)
+                foreach (var item in lista)
                 {
-                    listaFiltrada.Add(_entityMapper.CommentModelToCommentDto(item));
+                    if (item.News_Id == id)
+                    {
+                        listaFiltrada.Add(_entityMapper.CommentModelToCommentDto(item));
+                    }
                 }
             }
+            else listaFiltrada = null;
+
             return listaFiltrada;
         }
     }


### PR DESCRIPTION
Antes, al no haber ningún elemento en la lista en la que se agregaban los comentarios, no había qué agregar a la lista de comments relacionados al Id Novedad, por lo qe mostraba un error. Ahora, en caso de estar vacía, esta lista recibe un null.
![image (7)](https://user-images.githubusercontent.com/72093793/156447257-f7691f0b-d8aa-4764-bd52-0d5f4ffd52df.png)
 